### PR TITLE
Small improvements to e.bat

### DIFF
--- a/e.bat
+++ b/e.bat
@@ -1,4 +1,3 @@
 nasm -f bin basic.asm -Dcom_file=1 -o basic.com
 nasm -f bin basic.asm -l basic.lst -o basic.img
-rem basic
-
+@rem basic


### PR DESCRIPTION
This PR just removes some extra newlines in e.bat and adds an @ before `rem basic`. This makes it so the comment doesn't show up when the program is executed.

I'll probably do some more stuff with the batch file, but this is enough for now.